### PR TITLE
Allow more audio to be pulled out, plus more

### DIFF
--- a/lime.py
+++ b/lime.py
@@ -1,3 +1,4 @@
+#! /usr/bin/python
 # LIME Copyright (C) 2011 Matthew Thompson, Nick Thompson
 #
 # This file is part of LIME.
@@ -15,29 +16,31 @@
 # You should have received a copy of the GNU General Public License
 # along with LIME.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys, struct, wave
-try:
-    # Python 2 import
-    from StringIO import StringIO
-except ImportError:
-    # Python 3 import
-    import io.StringIO as StringIO
+import sys
+import struct
+import wave
+from StringIO import StringIO
+
+# UI elements
+from Tkinter import Tk
+from tkFileDialog import askopenfilename
 
 PREFIX = ''
+
 
 class Chunk(object):
     def __init__(self, file, datacallback=None, debug=False):
         self.debug = debug
         self.datacallback = datacallback
-    
+
         self.name = file.read(4)
         self.size = struct.unpack('<I', file.read(4))[0]
 
         if debug:
-            sys.stdout.write(PREFIX + "\nRead: " + self.name + " size " + str(self.size))
-        
+            print PREFIX + "\nRead: " + self.name + " size " + str(self.size)
+
         self.data = []
-        
+
         self.children = []
         self.header = None
         if self.name == 'LIST':
@@ -47,33 +50,32 @@ class Chunk(object):
             datacallback(self, file)
         else:
             file.seek(self.size, 1)
-            
+
     def read_children(self, file, stop):
         start = file.tell()
         global PREFIX
         PREFIX += "\t"
-        while file.tell() < stop-start:
+        while file.tell() < stop - start:
             self.children.append(Chunk(file, self.datacallback, self.debug))
         PREFIX = PREFIX[:-1]
-        
+
     def __repr__(self):
         return "Chunk %s (size %d) (%d children)" % (
             self.name, self.size, len(self.children)
         )
-        
 
-        
+
 class RIFF(object):
     def __init__(self, file, datacallback=None, debug=False):
         assert file.read(4) == 'RIFF'
-        self.size = struct.unpack('<I', file.read(4))[0] # total file size
-        self.name = file.read(4) # should be 'OMNI'
+        self.size = struct.unpack('<I', file.read(4))[0]  # total file size
+        self.name = file.read(4)  # should be 'OMNI'
         assert self.name == 'OMNI'
-        
+
         self.children = []
         while file.tell() < self.size + 4:
             self.children.append(Chunk(file, datacallback, debug))
-    
+
 
 def read_cstring(file):
     s = StringIO()
@@ -82,13 +84,13 @@ def read_cstring(file):
         s.write(c)
         c = file.read(1)
     return s.getvalue()
-    
-    
+
+
 def attacher(self, file):
     """Attaches blob data to the chunk in string form."""
     self.data = StringIO(file.read(self.size))
-    
-    
+
+
 def dumper(self, file):
     global NUM
     blob = file.read(self.size)
@@ -97,73 +99,129 @@ def dumper(self, file):
         listbegin = blob.find('LIST')
         idblock = StringIO(blob[:listbegin])
 
-        idblock.seek(15,1)
+        idblock.seek(15, 1)
         name = read_cstring(idblock)
-        #print 'WAV "%s" detected!' % name
-        
-        #out = open("%s.bin" % name, 'wb')
-        #out.write(blob)
-        #out.close()
-        
+
         blob = StringIO(blob[listbegin:])
         audiolist = Chunk(blob, attacher)
+<<<<<<< HEAD
         
         try:
             process_audio(name, audiolist.children)
         except wave.Error as e:
             sys.stdout.write('skipping\n')
+=======
+
+        try:
+            process_audio(name, audiolist.children)
+        # It ran into some non-audio data
+        except Exception:
+            print "Skipping...\n"
+
+>>>>>>> Changed exception to catch all errors, allowing more audio to be pulled out,
 
 def process_header(chunk):
-    data = chunk.data 
-    
-    data.seek(18,1)
+    data = chunk.data
+
+    data.seek(18, 1)
     bitrate1 = struct.unpack('<H', data.read(2))[0]
-    data.seek(2,1)
+    data.seek(2, 1)
     bitrate2 = struct.unpack('<H', data.read(2))[0]
-    data.seek(2,1)
+    data.seek(2, 1)
     idk = struct.unpack('<H', data.read(2))[0]
     bits = struct.unpack('<H', data.read(2))[0]
-    
-    sys.stdout.write("\nAudio format might be %dHz or %dHz, with %d bits\n" % (
-        bitrate1, bitrate2, bits
-    ))
-    
-    return {'sampwidth': bits/8, 'channels': 1, 'framerate': bitrate1}
-    
+
+    print "\nAudio format might be %dHz or %dHz, with %d bits\n" % (
+        bitrate1, bitrate2, bits)
+
+    return {'sampwidth': bits / 8, 'channels': 1, 'framerate': bitrate1}
+
 
 def process_audio(name, chunks):
     junk = 0
     valid = 0
-    
+
     head = chunks[0]
     wavinfo = process_header(head)
 
-    sys.stdout.write("\nWriting %s.wav\n" % name)
+    print "\nWriting %s.wav\n" % name
     out = wave.open("%s.wav" % name, 'wb')
     out.setnchannels(wavinfo['channels'])
     out.setframerate(wavinfo['framerate'])
     out.setsampwidth(wavinfo['sampwidth'])
-   
+
     for chunk in chunks[1:]:
         if chunk.name == 'MxCh':
             valid += 1
-            chunk.data.seek(14,0)
+            chunk.data.seek(14, 0)
             out.writeframes(chunk.data.read())
         else:
             junk += 1
-            
+
     out.close()
     print "stats: %d valid, %d junk" % (valid, junk)
-        
-    
-if __name__=='__main__':
-    try: 
-        filename = sys.argv[1]
-    except:
-        sys.stdout.write("\nUsage: %s file.si\n" % sys.argv[0])
+
+
+def main():
+    '''Simple GUI'''
+
+    print "\nWelcome to LIME\n"
+
+    # SI archive label
+    fileformat = [("SI Archive", "*.SI")]
+
+    # Draw (then withdraw) the root Tk window
+    root = Tk()
+    root.withdraw()
+
+    # Overwrite root display settings
+    root.overrideredirect(True)
+    root.geometry('0x0+0+0')
+
+    # Show window again, lift it so it can receive the focus
+    # Otherwise, it is behind the console window
+    root.deiconify()
+    root.lift()
+    root.focus_force()
+
+    # Select the SI archive
+    filename = askopenfilename(
+        parent=root,
+        title="Select a LEGO Island SI Archive",
+        defaultextension=".SI",
+        filetypes=fileformat
+    )
+
+    # The user clicked the cancel button
+    if len(filename) == 0:
+
+        # Give focus back to console window
+        root.destroy()
+
+        raw_input('''\nCould not find an SI Archive to extract!
+Press Enter to close LIME.\n''')
         raise SystemExit
-        
-    sys.stdout.write("\nReading %s" % filename)
-    sys.stdout.write("\n" + "-" * 40 + "\n")
-    
-    RIFF(open(filename, 'rb'), dumper, debug=True)
+
+    # The user selected a patch
+    else:
+
+        # Give focus back to console window
+        root.destroy()
+
+        # Display intro text
+        print "\nReading %s" % filename
+        print "\n" + "-" * 40 + "\n"
+
+        # Send archive to extractor
+        RIFF(open(filename, 'rb'), dumper, debug=True)
+
+if __name__ == "__main__":
+    try:
+        filename = sys.argv[1]
+
+        # Send archive to extractor
+        RIFF(open(filename, 'rb'), dumper, debug=True)
+
+    # The command-line argument was not invoked, open file dialog
+    except IndexError:
+        main()

--- a/lime.py
+++ b/lime.py
@@ -104,13 +104,6 @@ def dumper(self, file):
 
         blob = StringIO(blob[listbegin:])
         audiolist = Chunk(blob, attacher)
-<<<<<<< HEAD
-        
-        try:
-            process_audio(name, audiolist.children)
-        except wave.Error as e:
-            sys.stdout.write('skipping\n')
-=======
 
         try:
             process_audio(name, audiolist.children)
@@ -118,7 +111,6 @@ def dumper(self, file):
         except Exception:
             print "Skipping...\n"
 
->>>>>>> Changed exception to catch all errors, allowing more audio to be pulled out,
 
 def process_header(chunk):
     data = chunk.data

--- a/lime.py
+++ b/lime.py
@@ -17,6 +17,7 @@
 # along with LIME.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+import os
 import struct
 import wave
 from StringIO import StringIO
@@ -136,6 +137,10 @@ def process_audio(name, chunks):
     head = chunks[0]
     wavinfo = process_header(head)
 
+    # Change the working directory to extract_path
+    # so everything will extract to that location
+    os.chdir(extract_path)
+
     print "\nWriting %s.wav\n" % name
     out = wave.open("%s.wav" % name, 'wb')
     out.setnchannels(wavinfo['channels'])
@@ -152,6 +157,27 @@ def process_audio(name, chunks):
 
     out.close()
     print "stats: %d valid, %d junk" % (valid, junk)
+
+
+def FolPath(filename):
+    '''Sets the extraction path for the SI archive.
+    Works for both absolute and relative paths'''
+
+    # The folder name to extract the files to
+    foldername = os.path.dirname(sys.argv[0])
+
+    # The base filename (minus .SI)
+    basefilename = os.path.basename(filename[:-3])
+
+    # The complete location to extract the files to
+    extract_path = os.path.join(foldername, basefilename)
+
+    # If the folder does not exists, make it
+    if not os.path.exists(extract_path):
+        os.mkdir(extract_path)
+
+    # Send back the path
+    return extract_path
 
 
 def main():
@@ -185,7 +211,7 @@ def main():
     )
 
     # The user clicked the cancel button
-    if len(filename) == 0:
+    if not filename:
 
         # Give focus back to console window
         root.destroy()
@@ -194,15 +220,19 @@ def main():
 Press Enter to close LIME.\n''')
         raise SystemExit
 
-    # The user selected a patch
+    # The user selected an archive
     else:
 
         # Give focus back to console window
         root.destroy()
 
         # Display intro text
-        print "\nReading %s" % filename
-        print "\n" + "-" * 40 + "\n"
+        print "\nReading {0}".format(filename)
+        print "\n{0}\n".format("-" * 40)
+
+        # Run process to get the extraction path
+        global extract_path
+        extract_path = FolPath(filename)
 
         # Send archive to extractor
         RIFF(open(filename, 'rb'), dumper, debug=True)
@@ -210,6 +240,13 @@ Press Enter to close LIME.\n''')
 if __name__ == "__main__":
     try:
         filename = sys.argv[1]
+
+        # Run process to get the extraction path
+        extract_path = FolPath(filename)
+
+        # Display intro text
+        print "\nReading {0}".format(filename)
+        print "\n{0}\n".format("-" * 40)
 
         # Send archive to extractor
         RIFF(open(filename, 'rb'), dumper, debug=True)


### PR DESCRIPTION
Sorry for the late reply. After I saw Issue #3 and used it, I found that the was more than one error stopping every last piece (or so I guess) of audio from being pulled out. This PR fixes that, so all Exceptions are caught. In addition, this PR also contains....
- Fixes all PEP 8 errors,
- Removes broken Py3K code (I could not make it compatible at all. I'm not knowledgeable enough in Python to do that yet),
- Opens a Tkinter File Dialog if the command-line argument is not invoked (from another version of LIME we talked about in Issue #2)

I am very interesting in this project, as well as a whole international community, because LEGO Island is one of the most beloved LEGO video games, and as a modding community, LIME is of special interest because even the most skilled modders have been unable to open the SI archives to get the files out; LIME is the first successful program to ever do that.

The script has been tested successfully tested on Python 2.7.5 on Windows. :smile:

Oh, and a tip for the `rewrite` branch: when trying to extract the files, don't attempt to convert them or anything. As modders, our job is to get the files out in their original form, document the format and recreate it, and have the game load the new files. :wink:

Oh, and this PR would close #2 if you choose to merge it. :wink:
